### PR TITLE
Update data interval from 24 hours to 6 hours to reduce memory required

### DIFF
--- a/app/datastore/queries/BlocksPerHour.sql
+++ b/app/datastore/queries/BlocksPerHour.sql
@@ -1,5 +1,5 @@
 select date_trunc('hour', to_timestamp(burn_block_time)) AS hour, 
 COUNT(*)::int AS blocks 
 from blocks  
-where canonical  and burn_block_time>= EXTRACT(EPOCH FROM NOW() - INTERVAL '24 HOURS')::INTEGER 
+where canonical  and burn_block_time>= EXTRACT(EPOCH FROM NOW() - INTERVAL '6 HOURS')::INTEGER 
 group by 1 order by 1;

--- a/app/datastore/queries/PendingTxsInMempool.sql
+++ b/app/datastore/queries/PendingTxsInMempool.sql
@@ -1,1 +1,1 @@
-select date, size from stacks_blockchain_api.mempool_size where date >= now()- INTERVAL '24 HOURS';
+select date, size from stacks_blockchain_api.mempool_size where date >= now()- INTERVAL '6 HOURS';

--- a/app/datastore/queries/TPS.sql
+++ b/app/datastore/queries/TPS.sql
@@ -3,5 +3,5 @@ select
   CAST(SUM(tx_count)::float/3600 AS DECIMAL(10,2)) AS tps
 from blocks
 where canonical 
-and burn_block_time>= EXTRACT(EPOCH FROM NOW() - INTERVAL '24 HOURS')::INTEGER
+and burn_block_time>= EXTRACT(EPOCH FROM NOW() - INTERVAL '6 HOURS')::INTEGER
 group by 1 order by 1;

--- a/app/datastore/queries/TimeBetweenBlocks.sql
+++ b/app/datastore/queries/TimeBetweenBlocks.sql
@@ -4,5 +4,5 @@ SELECT
     burn_block_time - LAG(burn_block_time) OVER (ORDER BY burn_block_time) AS seconds_diff
 from blocks
 where canonical 
-and burn_block_time>= EXTRACT(EPOCH FROM NOW() - INTERVAL '24 HOURS')::INTEGER
+and burn_block_time>= EXTRACT(EPOCH FROM NOW() - INTERVAL '6 HOURS')::INTEGER
 order by 1;

--- a/app/datastore/queries/TxsPerBlock.sql
+++ b/app/datastore/queries/TxsPerBlock.sql
@@ -1,5 +1,5 @@
 select block_height, tx_count
 from blocks
 where canonical 
-and burn_block_time>= EXTRACT(EPOCH FROM NOW() - INTERVAL '24 HOURS')::INTEGER
+and burn_block_time>= EXTRACT(EPOCH FROM NOW() - INTERVAL '6 HOURS')::INTEGER
 order by 1;


### PR DESCRIPTION
sql queries should only check the past 6 hours, not 24 to reduce memory usage